### PR TITLE
Catch server startup errors

### DIFF
--- a/asserver/launcher.go
+++ b/asserver/launcher.go
@@ -31,7 +31,7 @@ func HttpServe(file, dir string, port int) {
 	// send xbmc the file query
 	go utils.Send("http", localip, file, port)
 
-	http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", port), nil)
+	log.Fatal(http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", port), nil));
 }
 
 // Serve STDIN stream from a local port


### PR DESCRIPTION
I've found that, if for some reasons port 8080 is already in use, idok quits without any warning.
By adding a log you can see what went wrong.