### PR TITLE
SDTIN stream fix: os.copy was not blocking

### DIFF
--- a/asserver/launcher.go
+++ b/asserver/launcher.go
@@ -53,6 +53,5 @@ func TCPServeStdin(port int) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	go io.Copy(c, os.Stdin)
-
+	io.Copy(c, os.Stdin)
 }

--- a/tunnel/launcher.go
+++ b/tunnel/launcher.go
@@ -80,5 +80,5 @@ func SshForwardStdin(config *ssh.ClientConfig) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	go io.Copy(c, os.Stdin)
+	io.Copy(c, os.Stdin)
 }


### PR DESCRIPTION
The stdin stream was not working: the server always stop as os.copy was non blocking
