### PR TITLE
Fix local IP addr lookup

### DIFF
--- a/utils/ip.go
+++ b/utils/ip.go
@@ -15,7 +15,6 @@ func GetLocalInterfaceIP() (string, error) {
 		log.Fatalf("Error while checking you interfaces: %v", err)
 	}
 	for _, ip := range ips {
-		mask := ip.DefaultMask()
 		for _, iface := range ifaces {
 			if iface.Flags&net.FlagLoopback != 0 {
 				continue
@@ -23,9 +22,11 @@ func GetLocalInterfaceIP() (string, error) {
 
 			addrs, _ := iface.Addrs()
 			for _, addr := range addrs {
+				_, subnet, _ := net.ParseCIDR(addr.String())
 				switch v := addr.(type) {
 				case *net.IPNet:
-					if v.Mask.String() == mask.String() {
+
+					if subnet.Contains(ip) {
 						return v.IP.String(), nil
 					}
 				}


### PR DESCRIPTION
In cases where the default subnet for an IPv4 private network does not
match the locally configured subnet on the interface, the local IP lookup
would fail.

Example: local ip 10.0.0.100/24, but the default subnet for this private
range is 10.0.0.0/8.

It would also fail for any IPv6 lookups since no default mask is defined
for private IPv6 ranges.

This mehtod of checking if the target IP address lies within the subnet
configured on the interface fixes both of those problems by not reying
on the default subnet at all but by reading the configured subnet from
the interfaces.